### PR TITLE
Initial Windows debugging implementation

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1,0 +1,56 @@
+[root]
+name = "server"
+version = "0.1.0"
+dependencies = [
+ "debug 0.1.0",
+]
+
+[[package]]
+name = "dbghelp-sys"
+version = "0.2.0"
+source = "git+https://github.com/team-worm/winapi-rs#4d8273c6337405f8ba76444a20b8888b473e4329"
+dependencies = [
+ "winapi 0.2.8 (git+https://github.com/team-worm/winapi-rs)",
+ "winapi-build 0.1.1 (git+https://github.com/team-worm/winapi-rs)",
+]
+
+[[package]]
+name = "debug"
+version = "0.1.0"
+dependencies = [
+ "dbghelp-sys 0.2.0 (git+https://github.com/team-worm/winapi-rs)",
+ "kernel32-sys 0.2.2 (git+https://github.com/team-worm/winapi-rs)",
+ "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (git+https://github.com/team-worm/winapi-rs)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "git+https://github.com/team-worm/winapi-rs#4d8273c6337405f8ba76444a20b8888b473e4329"
+dependencies = [
+ "winapi 0.2.8 (git+https://github.com/team-worm/winapi-rs)",
+ "winapi-build 0.1.1 (git+https://github.com/team-worm/winapi-rs)",
+]
+
+[[package]]
+name = "lazy_static"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "git+https://github.com/team-worm/winapi-rs#4d8273c6337405f8ba76444a20b8888b473e4329"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "git+https://github.com/team-worm/winapi-rs#4d8273c6337405f8ba76444a20b8888b473e4329"
+
+[metadata]
+"checksum dbghelp-sys 0.2.0 (git+https://github.com/team-worm/winapi-rs)" = "<none>"
+"checksum kernel32-sys 0.2.2 (git+https://github.com/team-worm/winapi-rs)" = "<none>"
+"checksum lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6abe0ee2e758cd6bc8a2cd56726359007748fbf4128da998b65d0b70f881e19b"
+"checksum winapi 0.2.8 (git+https://github.com/team-worm/winapi-rs)" = "<none>"
+"checksum winapi-build 0.1.1 (git+https://github.com/team-worm/winapi-rs)" = "<none>"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -3,4 +3,7 @@ name = "server"
 version = "0.1.0"
 authors = ["Russell Johnston <rpjohnst@gmail.com>"]
 
+[workspace]
+
 [dependencies]
+debug = { path = "debug" }

--- a/server/debug/Cargo.toml
+++ b/server/debug/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "debug"
+version = "0.1.0"
+authors = ["Russell Johnston <rpjohnst@gmail.com>"]
+
+[dependencies]
+winapi = { git = "https://github.com/team-worm/winapi-rs" }
+kernel32-sys = { git = "https://github.com/team-worm/winapi-rs" }
+dbghelp-sys = { git = "https://github.com/team-worm/winapi-rs" }
+lazy_static = "0.2"

--- a/server/debug/examples/trace.rs
+++ b/server/debug/examples/trace.rs
@@ -1,0 +1,169 @@
+extern crate debug;
+
+extern crate winapi;
+extern crate kernel32;
+
+use std::{env, mem, ptr};
+use std::collections::HashMap;
+use std::os::windows::io::AsRawHandle;
+
+fn main() {
+    let child = debug::Command::new(env::args().nth(1).unwrap())
+        .env_clear()
+        .debug()
+        .expect("failed to launch process");
+
+    let options = debug::SymbolHandler::get_options();
+    debug::SymbolHandler::set_options(winapi::SYMOPT_DEBUG | winapi::SYMOPT_LOAD_LINES | options);
+
+    let mut threads = HashMap::new();
+    let mut symbols = debug::SymbolHandler::initialize(child.as_raw_handle())
+        .expect("failed to initialize symbol handler");
+
+    let mut attached = false;
+
+    let mut done = false;
+    while !done {
+        let event = debug::DebugEvent::wait_event()
+            .expect("failed to get debug event");
+
+        let mut debug_continue = false;
+
+        use debug::DebugEventInfo::*;
+        match event.info {
+            // FIXME: currently this ignores cp.hProcess and thus only supports a single child
+            CreateProcess(cp) => {
+                threads.insert(event.thread_id, cp.hThread);
+
+                symbols.load_module(cp.hFile, cp.lpBaseOfImage as usize)
+                    .expect("failed to load module");
+
+                let address = unsafe { mem::transmute(cp.lpStartAddress) };
+                let (symbol, off) = symbols.symbol_from_address(address)
+                    .expect("failed to get symbol");
+
+                let name = symbol.name.to_string_lossy();
+                println!("create process: {} {}+{}", event.process_id, name, off);
+
+                if cp.hFile != ptr::null_mut() {
+                    unsafe { kernel32::CloseHandle(cp.hFile) };
+                }
+            }
+
+            ExitProcess(ep) => {
+                println!("exit process: {} ({})", event.process_id, ep.dwExitCode);
+                done = true;
+            }
+
+            CreateThread(ct) => {
+                println!(
+                    "create thread: {} {:#018x}",
+                    event.thread_id, unsafe { mem::transmute::<_, usize>(ct.lpStartAddress) }
+                );
+
+                threads.insert(event.thread_id, ct.hThread);
+            }
+
+            ExitThread(et) => {
+                println!("exit thread: {} ({})", event.thread_id, et.dwExitCode);
+
+                threads.remove(&event.thread_id);
+            }
+
+            LoadDll(ld) => {
+                println!("load dll: {:#018x}", ld.lpBaseOfDll as usize);
+
+                symbols.load_module(ld.hFile, ld.lpBaseOfDll as usize)
+                    .expect("failed to load module");
+
+                if ld.hFile != ptr::null_mut() {
+                    unsafe { kernel32::CloseHandle(ld.hFile) };
+                }
+            }
+
+            UnloadDll(ud) => {
+                println!("unload dll: {:#018x}", ud.lpBaseOfDll as usize);
+
+                let _ = symbols.unload_module(ud.lpBaseOfDll as usize);
+            }
+
+            OutputDebugString(ds) => {
+                let mut buffer = vec![0u8; ds.nDebugStringLength as usize];
+                child.read_memory(ds.lpDebugStringData as usize, &mut buffer)
+                    .expect("failed reading debug string");
+
+                let string = String::from_utf8_lossy(&buffer);
+                println!("{}", string);
+            }
+
+            Exception(e) => {
+                let er = &e.ExceptionRecord;
+
+                if !attached {
+                    attached = true;
+                } else if e.dwFirstChance == 0 {
+                    println!("passing on last chance exception");
+                } else {
+                    if er.ExceptionCode == winapi::EXCEPTION_BREAKPOINT {
+                        debug_continue = true;
+                    }
+
+                    let address = er.ExceptionAddress as usize;
+                    let (symbol, off) = symbols.symbol_from_address(address)
+                        .expect("failed to get symbol");
+
+                    let name = symbol.name.to_string_lossy();
+                    println!("exception {:x} at {}+{}", er.ExceptionCode, name, off);
+
+                    let walk = symbols.walk_stack(threads[&event.thread_id])
+                        .expect("failed to walk thread stack");
+                    for frame in walk {
+                        let ref context = frame.context;
+                        let ref stack = frame.stack;
+
+                        let address = stack.AddrPC.Offset as usize;
+                        let (symbol, off) = symbols.symbol_from_address(address)
+                            .expect("failed to get symbol");
+
+                        let file_pos = symbols.line_from_address(address)
+                            .map(|(file, line, _off)| {
+                                format!("{}:{}", file.to_string_lossy(), line)
+                            })
+                            .unwrap_or(String::new());
+
+                        let name = symbol.name.to_string_lossy();
+                        println!("  0x{:016x} {}+{} {}", address, name, off, file_pos);
+
+                        let _ = symbols.enumerate_symbols(&frame, |symbol, size| {
+                            if size == 0 { return true; }
+
+                            let name = symbol.name.to_string_lossy();
+
+                            let mut buffer = vec![0u8; size];
+                            match child.read_memory(
+                                context.Rbp as usize + symbol.address, &mut buffer
+                            ) {
+                                Ok(_) => {
+                                    let value = match size {
+                                        4 => unsafe { *(buffer.as_ptr() as *const u32) as u64 },
+                                        8 => unsafe { *(buffer.as_ptr() as *const u64) as u64 },
+                                        _ => unsafe { *(buffer.as_ptr() as *const u32) as u64 },
+                                    };
+                                    println!("    {} = {:x}", name, value);
+                                }
+                                Err(_) => println!("    {} = ?", name),
+                            }
+
+                            true
+                        });
+                    }
+                }
+            }
+
+            Rip(..) => println!("rip event"),
+        }
+
+        event.continue_event(debug_continue)
+            .expect("failed to continue thread");
+    }
+}

--- a/server/debug/src/debug.rs
+++ b/server/debug/src/debug.rs
@@ -1,0 +1,93 @@
+use std::{io, mem};
+
+use winapi;
+use kernel32;
+
+/// An event received from a child process
+pub struct DebugEvent {
+    pub process_id: u32,
+    pub thread_id: u32,
+    pub info: DebugEventInfo,
+}
+
+impl !Send for DebugEvent {}
+
+// TODO: replace raw win32 structs with idiomatic types
+pub enum DebugEventInfo {
+    CreateProcess(winapi::CREATE_PROCESS_DEBUG_INFO),
+    ExitProcess(winapi::EXIT_PROCESS_DEBUG_INFO),
+    CreateThread(winapi::CREATE_THREAD_DEBUG_INFO),
+    ExitThread(winapi::EXIT_THREAD_DEBUG_INFO),
+    LoadDll(winapi::LOAD_DLL_DEBUG_INFO),
+    UnloadDll(winapi::UNLOAD_DLL_DEBUG_INFO),
+    OutputDebugString(winapi::OUTPUT_DEBUG_STRING_INFO),
+    Exception(winapi::EXCEPTION_DEBUG_INFO),
+    Rip(winapi::RIP_INFO),
+}
+
+impl DebugEvent {
+    /// Retrieve the next `DebugEvent` from any child process attached to the curent thread
+    pub fn wait_event() -> io::Result<DebugEvent> {
+        unsafe {
+            let mut event = mem::uninitialized();
+            if kernel32::WaitForDebugEvent(&mut event, winapi::INFINITE) == winapi::FALSE {
+                return Err(io::Error::last_os_error());
+            }
+
+            let process_id = event.dwProcessId;
+            let thread_id = event.dwThreadId;
+
+            use self::DebugEventInfo::*;
+            let info = match event.dwDebugEventCode {
+                winapi::CREATE_PROCESS_DEBUG_EVENT => CreateProcess(*event.CreateProcessInfo()),
+                winapi::EXIT_PROCESS_DEBUG_EVENT => ExitProcess(*event.ExitProcess()),
+                winapi::CREATE_THREAD_DEBUG_EVENT => CreateThread(*event.CreateThread()),
+                winapi::EXIT_THREAD_DEBUG_EVENT => ExitThread(*event.ExitThread()),
+                winapi::LOAD_DLL_DEBUG_EVENT => LoadDll(*event.LoadDll()),
+                winapi::UNLOAD_DLL_DEBUG_EVENT => UnloadDll(*event.UnloadDll()),
+                winapi::OUTPUT_DEBUG_STRING_EVENT => OutputDebugString(*event.DebugString()),
+                winapi::EXCEPTION_DEBUG_EVENT => Exception(*event.Exception()),
+                winapi::RIP_EVENT => Rip(*event.RipInfo()),
+
+                _ => unreachable!()
+            };
+
+            Ok(DebugEvent { process_id, thread_id, info })
+        }
+    }
+
+    /// Continue the child process that generated this event
+    ///
+    /// For `DebugEventInfo::Exception` events, `handled` signifies whether the debugger handled
+    /// the exception. If `handled == false`, the exception is passed on to the child process.
+    pub fn continue_event(mut self, handled: bool) -> io::Result<()> {
+        let status = if handled {
+            winapi::DBG_CONTINUE
+        } else {
+            winapi::DBG_EXCEPTION_NOT_HANDLED
+        } as winapi::DWORD;
+
+        self.continue_status(status)?;
+
+        mem::forget(self);
+        Ok(())
+    }
+
+    fn continue_status(&mut self, status: winapi::DWORD) -> io::Result<()> {
+        let DebugEvent { ref process_id, ref thread_id, .. } = *self;
+
+        unsafe {
+            if kernel32::ContinueDebugEvent(*process_id, *thread_id, status) == winapi::FALSE {
+                return Err(io::Error::last_os_error());
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Drop for DebugEvent {
+    fn drop(&mut self) {
+        let _ = self.continue_status(winapi::DBG_EXCEPTION_NOT_HANDLED as winapi::DWORD);
+    }
+}

--- a/server/debug/src/lib.rs
+++ b/server/debug/src/lib.rs
@@ -1,0 +1,17 @@
+#![feature(optin_builtin_traits)]
+#![feature(field_init_shorthand)]
+
+extern crate winapi;
+extern crate kernel32;
+extern crate dbghelp;
+
+#[macro_use]
+extern crate lazy_static;
+
+pub use process::*;
+pub use debug::*;
+pub use symbol::*;
+
+mod process;
+mod debug;
+mod symbol;

--- a/server/debug/src/process.rs
+++ b/server/debug/src/process.rs
@@ -1,0 +1,187 @@
+use std::{io, env, iter, mem, ptr};
+use std::ffi::{OsString, OsStr};
+use std::os::windows::ffi::OsStrExt;
+use std::os::windows::io::{RawHandle, AsRawHandle, IntoRawHandle};
+use std::collections::HashMap;
+
+use winapi;
+use kernel32;
+
+/// A running or exited debugee process, created via a `Command`
+pub struct Child(winapi::HANDLE);
+
+impl Child {
+    pub fn read_memory(&self, address: usize, buffer: &mut [u8]) -> io::Result<usize> {
+        unsafe {
+            let mut read = 0;
+            if kernel32::ReadProcessMemory(
+                self.0, address as winapi::LPCVOID,
+                buffer.as_mut_ptr() as winapi::PVOID, buffer.len() as winapi::DWORD64,
+                &mut read
+            ) == winapi::FALSE {
+                return Err(io::Error::last_os_error());
+            }
+
+            Ok(read as usize)
+        }
+    }
+}
+
+impl AsRawHandle for Child {
+    fn as_raw_handle(&self) -> RawHandle { self.0 }
+}
+
+impl IntoRawHandle for Child {
+    fn into_raw_handle(self) -> RawHandle { self.0 }
+}
+
+/// Custom implementation of `std::process::Command` to debug child processes.
+/// Lacks some features that we don't need:
+///
+/// * Does not look up `program` in `PATH`
+/// * Child does not inherit stdio handles
+pub struct Command {
+    program: OsString,
+    args: Vec<OsString>,
+    env: Option<HashMap<OsString, OsString>>,
+}
+
+impl Command {
+    /// Construct a new `Command` with default configuration:
+    ///
+    /// * No arguments
+    /// * Inherit parent environment
+    /// * Inherit parent working directory
+    pub fn new<S: AsRef<OsStr>>(program: S) -> Command {
+        Command {
+            program: program.as_ref().to_os_string(),
+            args: vec![],
+            env: None,
+        }
+    }
+
+    /// Add an argument to pass to the program.
+    pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Command {
+        self.args.push(arg.as_ref().to_os_string());
+        self
+    }
+
+    fn init_env_map(&mut self) {
+        if self.env.is_none() {
+            self.env = Some(env::vars_os().collect());
+        }
+    }
+
+    /// Add a variable to the child process's environment.
+    pub fn env<K, V>(&mut self, key: K, value: V) -> &mut Command
+        where K: AsRef<OsStr>, V: AsRef<OsStr>
+    {
+        self.init_env_map();
+        self.env.as_mut().unwrap().insert(
+            key.as_ref().to_os_string(), value.as_ref().to_os_string()
+        );
+        self
+    }
+
+    /// Clear the environment of the child process.
+    pub fn env_clear(&mut self) -> &mut Command {
+        self.env = Some(HashMap::new());
+        self
+    }
+
+    /// Execute the command as a child process and return a handle to it.
+    pub fn debug(&mut self) -> io::Result<Child> {
+        let mut si = winapi::STARTUPINFOW {
+            cb: mem::size_of::<winapi::STARTUPINFOW>() as winapi::DWORD,
+            ..unsafe { mem::zeroed() }
+        };
+
+        let mut cmd = make_command_line(&self.program, &self.args)?;
+        let (env, _env) = make_env(self.env.as_ref())?;
+
+        let mut pi = unsafe { mem::zeroed() };
+        unsafe {
+            if kernel32::CreateProcessW(
+                ptr::null(), cmd.as_mut_ptr(), ptr::null_mut(), ptr::null_mut(), winapi::FALSE,
+                winapi::CREATE_NEW_CONSOLE | winapi::DEBUG_ONLY_THIS_PROCESS,
+                env as *mut winapi::VOID, ptr::null(), &mut si, &mut pi
+            ) != winapi::TRUE {
+                return Err(io::Error::last_os_error())
+            }
+
+            kernel32::CloseHandle(pi.hThread);
+            Ok(Child(pi.hProcess))
+        }
+    }
+}
+
+fn make_command_line(program: &OsStr, args: &[OsString]) -> io::Result<Vec<u16>> {
+    let mut cmd = vec![];
+    append(&mut cmd, program)?;
+    for arg in args {
+        cmd.push(' ' as u16);
+        append(&mut cmd, arg)?
+    }
+    cmd.push(0);
+    return Ok(cmd);
+
+    fn append(cmd: &mut Vec<u16>, arg: &OsStr) -> io::Result<()> {
+        ensure_no_nuls(arg)?;
+        if !arg.is_empty() && !arg.encode_wide().any(|c| c == ' ' as u16 || c == '\t' as u16) {
+            cmd.extend(arg.encode_wide());
+            Ok(())
+        } else {
+            cmd.push('"' as u16);
+
+            let mut iter = arg.encode_wide();
+            loop {
+                let backslashes = iter.clone().take_while(|&c| c == '\\' as u16).count();
+                for _ in 0..backslashes { iter.next(); }
+
+                match iter.next() {
+                    Some(c) => {
+                        let bs = if c == '"' as u16 { 2 * backslashes + 1 } else { backslashes };
+                        cmd.extend(iter::repeat('\\' as u16).take(bs));
+                        cmd.push(c);
+                    },
+                    None => {
+                        cmd.extend(iter::repeat('\\' as u16).take(2 * backslashes));
+                        break;
+                    },
+                }
+            }
+
+            cmd.push('"' as u16);
+            Ok(())
+        }
+    }
+}
+
+fn make_env(
+    env: Option<&HashMap<OsString, OsString>>
+) -> io::Result<(*mut winapi::VOID, Vec<u16>)> {
+    match env {
+        Some(env) => {
+            let mut block = vec![];
+            for pair in env {
+                block.extend(ensure_no_nuls(pair.0)?.encode_wide());
+                block.push('=' as u16);
+                block.extend(ensure_no_nuls(pair.1)?.encode_wide());
+                block.push(0);
+            }
+            block.push(0);
+
+            Ok((block.as_mut_ptr() as *mut winapi::VOID, block))
+        }
+
+        None => Ok((ptr::null_mut(), vec![]))
+    }
+}
+
+fn ensure_no_nuls<S: AsRef<OsStr>>(s: S) -> io::Result<S> {
+    if s.as_ref().encode_wide().any(|b| b == 0) {
+        Err(io::Error::new(io::ErrorKind::InvalidInput, "nul byte found in provided data"))
+    } else {
+        Ok(s)
+    }
+}

--- a/server/debug/src/symbol.rs
+++ b/server/debug/src/symbol.rs
@@ -1,0 +1,254 @@
+use std::{io, slice, ptr, mem};
+use std::sync::Mutex;
+use std::ffi::OsString;
+use std::os::windows::ffi::OsStringExt;
+
+use winapi;
+use kernel32;
+use dbghelp;
+
+lazy_static! {
+    static ref HANDLE: Mutex<Handle> = Mutex::new(Handle(None));
+}
+
+struct Handle(Option<winapi::HANDLE>);
+unsafe impl Send for Handle {}
+unsafe impl Sync for Handle {}
+
+pub struct SymbolHandler(winapi::HANDLE);
+
+impl SymbolHandler {
+    pub fn get_options() -> winapi::DWORD {
+        unsafe { dbghelp::SymGetOptions() }
+    }
+
+    pub fn set_options(options: winapi::DWORD) {
+        unsafe { dbghelp::SymSetOptions(options) };
+    }
+
+    /// Initialize the process's symbol handler
+    ///
+    /// A process can only contain a single symbol handler. This function will fail if one already
+    /// exists.
+    pub fn initialize(process: winapi::HANDLE) -> io::Result<SymbolHandler> {
+        let Handle(ref mut handle) = *HANDLE.lock().unwrap();
+        if handle.is_some() {
+            return Err(io::Error::new(io::ErrorKind::AlreadyExists, "symbol handler"));
+        }
+
+        unsafe {
+            if dbghelp::SymInitializeW(process, ptr::null(), winapi::FALSE) == winapi::FALSE {
+                return Err(io::Error::last_os_error());
+            }
+        }
+
+        *handle = Some(process);
+        Ok(SymbolHandler(process))
+    }
+
+    /// Load the symbols for a module
+    pub fn load_module(&mut self, file: winapi::HANDLE, base: usize) -> io::Result<()> {
+        unsafe {
+            // TODO: if we want to enable deferred symbol loading, we need to pass module size too
+            if dbghelp::SymLoadModuleExW(
+                self.0, file, ptr::null(), ptr::null(),
+                base as winapi::DWORD64, 0, ptr::null_mut(), 0
+            ) == 0 {
+                return Err(io::Error::last_os_error());
+            }
+
+            Ok(())
+        }
+    }
+
+    /// Unload the symbols for a module
+    pub fn unload_module(&mut self, base: usize) -> io::Result<()> {
+        unsafe {
+            if dbghelp::SymUnloadModule64(self.0, base as winapi::DWORD64) == winapi::FALSE {
+                return Err(io::Error::last_os_error());
+            }
+
+            Ok(())
+        }
+    }
+
+    /// Retrieve the symbol and byte offset of an address
+    pub fn symbol_from_address(&mut self, address: usize) -> io::Result<(Symbol, usize)> {
+        unsafe {
+            let mut displacement = 0;
+            let mut symbol = (winapi::SYMBOL_INFOW {
+                SizeOfStruct: mem::size_of::<winapi::SYMBOL_INFOW>() as winapi::ULONG,
+                MaxNameLen: winapi::MAX_SYM_NAME as winapi::ULONG,
+                ..mem::zeroed()
+            }, [0 as winapi::WCHAR; (winapi::MAX_SYM_NAME - 1) as usize]);
+
+            if dbghelp::SymFromAddrW(
+                self.0, address as winapi::DWORD64, &mut displacement, &mut symbol.0
+            ) == winapi::FALSE {
+                return Err(io::Error::last_os_error());
+            }
+
+            let name = slice::from_raw_parts(symbol.0.Name.as_ptr(), symbol.0.NameLen as usize);
+            let name = OsString::from_wide(name);
+
+            Ok((Symbol { name, address: symbol.0.Address as usize }, displacement as usize))
+        }
+    }
+
+    /// Retrieve the filename, line number, and byte offset of an instruction address
+    pub fn line_from_address(&mut self, address: usize) -> io::Result<(OsString, u32, usize)> {
+        unsafe {
+            let mut displacement = 0;
+            let mut line = winapi::IMAGEHLP_LINEW64 {
+                SizeOfStruct: mem::size_of::<winapi::IMAGEHLP_LINEW64>() as winapi::DWORD,
+                ..mem::zeroed()
+            };
+
+            if dbghelp::SymGetLineFromAddrW64(
+                self.0, address as winapi::DWORD64, &mut displacement, &mut line
+            ) == winapi::FALSE {
+                return Err(io::Error::last_os_error());
+            }
+
+            let mut len = 0;
+            while *line.FileName.offset(len as isize) != 0 { len += 1; }
+
+            let name = slice::from_raw_parts(line.FileName, len);
+            let name = OsString::from_wide(name);
+
+            Ok((name, line.LineNumber, displacement as usize))
+        }
+    }
+
+    /// Iterate through the frames of a thread's stack
+    ///
+    /// The thread should be part of an attached child process which is currently paused to handle
+    /// a debug event.
+    pub fn walk_stack(&mut self, thread: winapi::HANDLE) -> io::Result<StackFrames> {
+        unsafe {
+            let mut context = winapi::CONTEXT {
+                ContextFlags: winapi::CONTEXT_FULL,
+                ..mem::zeroed()
+            };
+            if kernel32::GetThreadContext(thread, &mut context) == winapi::FALSE {
+                return Err(io::Error::last_os_error());
+            }
+
+            fn flat(address: winapi::DWORD64) -> winapi::ADDRESS64 {
+                winapi::ADDRESS64 { Offset: address, Mode: winapi::AddrModeFlat, Segment: 0 }
+            }
+            let stack = winapi::STACKFRAME64 {
+                AddrPC: flat(context.Rip),
+                AddrFrame: flat(context.Rbp),
+                AddrStack: flat(context.Rsp),
+                ..mem::zeroed()
+            };
+
+            Ok(StackFrames { process: self.0, thread, context, stack })
+        }
+    }
+
+    /// Enumerate the local symbols of a stack frame
+    ///
+    /// Addresses are base-pointer-relative.
+    pub fn enumerate_symbols<F>(&self, frame: &StackFrame, mut f: F) -> io::Result<()>
+        where F: FnMut(&Symbol, usize) -> bool
+    {
+        unsafe {
+            let mut stack_frame = winapi::IMAGEHLP_STACK_FRAME {
+                InstructionOffset: frame.stack.AddrPC.Offset,
+                ..mem::zeroed()
+            };
+            if dbghelp::SymSetContext(self.0, &mut stack_frame, ptr::null_mut()) == winapi::FALSE {
+                return Err(io::Error::last_os_error());
+            }
+
+            if dbghelp::SymEnumSymbolsW(
+                self.0, 0, ptr::null(), Some(enum_symbols::<F>), &mut f as *mut _ as *mut _
+            ) == winapi::FALSE {
+                return Err(io::Error::last_os_error());
+            }
+
+            return Ok(());
+        }
+
+        #[allow(non_snake_case)]
+        unsafe extern "system" fn enum_symbols<F>(
+            pSymInfo: winapi::PSYMBOL_INFOW, SymbolSize: winapi::ULONG, UserContext: winapi::PVOID
+        ) -> winapi::BOOL
+            where F: FnMut(&Symbol, usize) -> bool
+        {
+            let symbol = &*pSymInfo;
+            let mut f = &mut *(UserContext as *mut F);
+
+            // for some reason, pSymInfo.NameLen includes the null terminator here
+            let mut len = 0;
+            while *symbol.Name.as_ptr().offset(len as isize) != 0 { len += 1; }
+            let wchars = slice::from_raw_parts(symbol.Name.as_ptr(), len);
+            let name = OsString::from_wide(wchars);
+
+            let symbol = Symbol { name, address: symbol.Address as usize };
+            if f(&symbol, SymbolSize as usize) { winapi::TRUE } else { winapi::FALSE }
+        }
+    }
+}
+
+impl Drop for SymbolHandler {
+    fn drop(&mut self) {
+        let Handle(ref mut handle) = *HANDLE.lock().unwrap();
+
+        unsafe {
+            dbghelp::SymCleanup(self.0);
+        }
+
+        *handle = None;
+    }
+}
+
+/// The name and address of a debugging symbol
+///
+/// Will be expanded on to include type information, etc.
+pub struct Symbol {
+    pub name: OsString,
+    pub address: usize,
+}
+
+/// An iterator of the frames in a thread's stack
+pub struct StackFrames {
+    process: winapi::HANDLE,
+    thread: winapi::HANDLE,
+    context: winapi::CONTEXT,
+    stack: winapi::STACKFRAME64,
+}
+
+/// A single stack frame and the context needed to read it
+pub struct StackFrame {
+    pub context: winapi::CONTEXT,
+    pub stack: winapi::STACKFRAME64,
+}
+
+impl Iterator for StackFrames {
+    type Item = StackFrame;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        #[cfg(target_arch = "x86_64")]
+        const MACHINE_TYPE: winapi::DWORD = winapi::IMAGE_FILE_MACHINE_AMD64 as winapi::DWORD;
+
+        unsafe {
+            if dbghelp::StackWalk64(
+                MACHINE_TYPE, self.process, self.thread,
+                &mut self.stack, &mut self.context as *mut _ as *mut _,
+                None, Some(dbghelp::SymFunctionTableAccess64), Some(dbghelp::SymGetModuleBase64),
+                None
+            ) == winapi::FALSE {
+                return None;
+            }
+
+            if self.stack.AddrPC.Offset == 0 {
+                return None;
+            }
+
+            Some(StackFrame { context: self.context, stack: self.stack })
+        }
+    }
+}


### PR DESCRIPTION
This adds a new library crate called `debug` for `server` to use. Currently Windows-only and still requires some direct use of the Windows API. Provides initial implementation of the following features:

* Process launching
* Debug events
* Symbol and line lookup
* stack tracing
* Local variable enumeration

Resolves #3 