### PR TITLE
API Definitions for SourceTypeDefinitions and SourceValues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # SPICE
 
+##[View API Documentation](docs/api/v1.md)
+
 Spice is a visual, interactive debugger that transcends time.

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -17,7 +17,7 @@ Path parameters:
 
 Responses:
  - `200`: Successfully got contents of path.
-    - Returns {[File](#file)}
+    - Returns {[SourceFile](#sourcefile)}
  - `400`: Invalid path.
     - Returns {[Error](#error)}
  - `403`: Insufficient privileges to open file.
@@ -51,7 +51,7 @@ may have some fields omitted for brevity.
     2. Response: AttachInfo `{id: 1, sourcePath"/home/src"}`
  2. Get directory info and source code
     1. Request `GET /api/v1/filesystem/home/src`
-    2. Response: File `{fType: "directory", contents:[{fType: "file", name: "hello.cpp"}]}`
+    2. Response: [SourceFile](#sourcefile) `{fType: "directory", contents:[{fType: "file", name: "hello.cpp"}]}`
     3. Request `GET /files/home/src/hello.cpp`
     4. Response: Binary contents of `hello.cpp`
  3. Get list of all functions
@@ -321,7 +321,7 @@ Responses:
 }
 ```
 
-### File
+### SourceFile
 ```
 {
     name {string}: Name of file
@@ -329,7 +329,7 @@ Responses:
     fType {string}: File type ("file" or "directory")
     contents: {object[]}:
         If ftype="file", undefined
-        If ftype="directory", an array of Files inside the directory. Subdirectories have "contents" field set to undefined so the entire directory subtree is not returned.
+        If ftype="directory", an array of SourceFiles inside the directory. Subdirectories have "contents" field set to undefined so the entire directory subtree is not returned.
 }
 ```
 
@@ -350,7 +350,7 @@ Responses:
    executionTime {integer}: Nanoseconds
    data {object}: Data specific to this eType
       if `eType=function`: {
-         function {[Function](#function)}: Function that produced this execution
+         sFunction {[SourceFunction](#sourcefunction)}: Function that produced this execution
       }
       if `eType=process`: {
          nextExecution {Execution id}: Id of the execution that follows this one. Null until `status=done`. Initially set to `null`, set when a call to `/debug/execute` hits a breakpoint, in which case it points to the breakpoint function’s execution.
@@ -380,7 +380,7 @@ Responses:
 }
 ```
 
-### Function
+### SourceFunction
 ```
 {
    address {integer}: Memory address of the function
@@ -388,8 +388,8 @@ Responses:
    sourcePath {string}: Full path to the source code
    lineNumber {integer}: Line number of the function definition
    lineCount {integer}: Length of function in source code lines
-   parameters {Variable[]}: Array of parameter variables
-   localVariables {Variable[]): Array of all local variables defined in function
+   parameters {[SourceVariable](#sourcevariable)[]}: Array of parameter variables
+   localVariables {[SourceVariable](#sourcevariable)[]): Array of all local variables defined in function
 }
 ```
 
@@ -405,24 +405,57 @@ Responses:
 ### Breakpoint
 ```
 {
-  function {[Function](#Function)}: The function that this is breakpoint is associated with.
+  sFunction {[SourceFunction](#sourcefunction)}: The function that this is breakpoint is associated with.
   metadata {string}: Any additional info associated with this breakpoint.
 }
 ```
 
-### Variable
+### SourceVariable
 ```
 {
   id {var id}: Unique identifier of that variable.
   name {string}: Name of the variable as it appears in the function.
-  sType {SourceType}: Type of the variable as it is defined in the source code.
+  sTypeIndex {number}: Index to the variable in the [SourceType](#sourcetype)[] as it is defined in the source code.
   address {integer}: Memory address
 }
 ```
 
 ### SourceType
-TODO
+```
+{
+  sTypeIndex {integer}: Index into SourceTypeDefinition array of the type that this variable is.
+  data {boolean | integer | double | null}: Only used if sTypeIndex points to a type of `kind == "primitive"`. Contains the primitive data.
+  target {integer}: Only used if sTypeIndex points to a type of `kind == "pointer"`. Contains the index into the SourceType array that this points to.
+  fields { name {string}: integer}: Only used if sTypeIndex points to a type of `kind == "struct"`. Map of indexes into the SourceType array that contain definitions for each field of a given name. 
+}
+```
 
+### SourceTypeDefinition
+```
+{
+  kind {string}: Type of variable. Can be "primitive" | "pointer" | "struct".
+  primitive {[SourcePrimativeDefinition](#sourceprimativedefinition)}: Only used if `kind == "primitive"`. Defines primitive information
+  sTypeIndex {integer}: Only used if `kind == "pointer"`. Index into array of SourceTypeDefinitions array of the type that this pointer points to.
+  name {string}: Only used if `kind == "struct"`. Name of the struct as used in source code.
+  fields {[SourceStructFieldDefinition](#sourcestructfielddefinition)[]}: Only used if `kind == "struct"`. Array of fields on this struct.
+}
+```
+
+### SourcePrimativeDefinition
+```
+{
+  type {string}: Type of primitive. Can be "void" | "bool" | "int" | "float".
+  signed {boolean}: Only used if `type == "int"`
+}
+```
+
+### SourceStructFieldDefinition
+```
+{
+  name {string}: Name of field on struct.
+  sTypeIndex {integer}: Index into SourceTypeDefinition array of the type that this field is.
+}
+```
 
 
 # Error Codes

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -350,7 +350,7 @@ Responses:
    executionTime {integer}: Nanoseconds
    data {object}: Data specific to this eType
       if `eType=function`: {
-         sFunction {[SourceFunction](#sourcefunction)}: Function that produced this execution
+         sFunction {SourceFunction}: Function that produced this execution
       }
       if `eType=process`: {
          nextExecution {Execution id}: Id of the execution that follows this one. Null until `status=done`. Initially set to `null`, set when a call to `/debug/execute` hits a breakpoint, in which case it points to the breakpoint function’s execution.
@@ -388,8 +388,8 @@ Responses:
    sourcePath {string}: Full path to the source code
    lineNumber {integer}: Line number of the function definition
    lineCount {integer}: Length of function in source code lines
-   parameters {[SourceVariable](#sourcevariable)[]}: Array of parameter variables
-   localVariables {[SourceVariable](#sourcevariable)[]): Array of all local variables defined in function
+   parameters {SourceVariable[]}: Array of parameter variables
+   localVariables {SourceVariable[]): Array of all local variables defined in function
 }
 ```
 
@@ -397,7 +397,7 @@ Responses:
 ```
 {
   id {DebugId}
-  attachedProcess {[Process](#process)}
+  attachedProcess {Process}
   sourcePath {string}: Path to root directory of source code
 }
 ```
@@ -405,7 +405,7 @@ Responses:
 ### Breakpoint
 ```
 {
-  sFunction {[SourceFunction](#sourcefunction)}: The function that this is breakpoint is associated with.
+  sFunction {SourceFunction}: The function that this is breakpoint is associated with.
   metadata {string}: Any additional info associated with this breakpoint.
 }
 ```
@@ -415,7 +415,7 @@ Responses:
 {
   id {var id}: Unique identifier of that variable.
   name {string}: Name of the variable as it appears in the function.
-  sTypeIndex {number}: Index to the variable in the [SourceType](#sourcetype)[] as it is defined in the source code.
+  sTypeIndex {number}: Index to the variable in the SourceType[] as it is defined in the source code.
   address {integer}: Memory address
 }
 ```
@@ -434,10 +434,10 @@ Responses:
 ```
 {
   kind {string}: Type of variable. Can be "primitive" | "pointer" | "struct".
-  primitive {[SourcePrimativeDefinition](#sourceprimativedefinition)}: Only used if `kind == "primitive"`. Defines primitive information
+  primitive {SourcePrimativeDefinition}: Only used if `kind == "primitive"`. Defines primitive information
   sTypeIndex {integer}: Only used if `kind == "pointer"`. Index into array of SourceTypeDefinitions array of the type that this pointer points to.
   name {string}: Only used if `kind == "struct"`. Name of the struct as used in source code.
-  fields {[SourceStructFieldDefinition](#sourcestructfielddefinition)[]}: Only used if `kind == "struct"`. Array of fields on this struct.
+  fields {SourceStructFieldDefinition[]}: Only used if `kind == "struct"`. Array of fields on this struct.
 }
 ```
 

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -417,6 +417,7 @@ Todo....
 {
   id {var id}: Unique identifier of that variable.
   name {string}: Name of the variable as it appears in the function.
+  sTypeIndex {integer}: Index into SourceType array of the type that this variable is.
   sValueIndex {number}: Index to the variable in the SourceValue[] as it is defined in the source code.
   address {integer}: Memory address
 }
@@ -425,7 +426,7 @@ Todo....
 ### SourceValue
 ```
 {
-  sTypeIndex {integer}: Index into SourceTypeDefinition array of the type that this variable is.
+  sTypeIndex {integer}: Index into SourceType array of the type that this value is.
   data If `kind == "primitive"` {boolean | integer | double | null}: Contains the primitive data.
        If `kind == "pointer"` {integer}: Contains the index into the SourceType array that this points to.
 	   If `kind == "struct"` {name {string}: integer}: Map of indexes into the SourceType array that contain definitions for each field of a given name. 

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -426,36 +426,30 @@ Todo....
 ```
 {
   sTypeIndex {integer}: Index into SourceTypeDefinition array of the type that this variable is.
-  data {boolean | integer | double | null}: Only used if sTypeIndex points to a type of `kind == "primitive"`. Contains the primitive data.
-  target {integer}: Only used if sTypeIndex points to a type of `kind == "pointer"`. Contains the index into the SourceType array that this points to.
-  fields { name {string}: integer}: Only used if sTypeIndex points to a type of `kind == "struct"`. Map of indexes into the SourceType array that contain definitions for each field of a given name. 
+  data If `kind == "primitive"` {boolean | integer | double | null}: Contains the primitive data.
+       If `kind == "pointer"` {integer}: Contains the index into the SourceType array that this points to.
+	   If `kind == "struct"` {name {string}: integer}: Map of indexes into the SourceType array that contain definitions for each field of a given name. 
 }
 ```
 
-### SourceTypeDefinition
+### SourceType
 ```
 {
   kind {string}: Type of variable. Can be "primitive" | "pointer" | "struct".
-  primitive {SourcePrimitiveDefinition}: Only used if `kind == "primitive"`. Defines primitive information
-  sTypeIndex {integer}: Only used if `kind == "pointer"`. Index into array of SourceTypeDefinitions array of the type that this pointer points to.
-  name {string}: Only used if `kind == "struct"`. Name of the struct as used in source code.
-  fields {SourceStructFieldDefinition[]}: Only used if `kind == "struct"`. Array of fields on this struct.
+  sTypeIndex {integer}: Only used if `kind == "pointer"`. Index into array of SourceType array of the type that this pointer points to.
+  name {string}: If `kind == "primitive"` can be "void" | "bool" | "int" | "uint" | "float". 
+			     If `kind == "struct"` is name of struct. 
+				 If `kind == "pointer"` is unused.
+  fields {SourceTypeField[]}: Only used if `kind == "struct"`. Array of fields on this struct.
+  size {integer}: Size in bytes.
 }
 ```
 
-### SourcePrimitiveDefinition
-```
-{
-  type {string}: Type of primitive. Can be "void" | "bool" | "int" | "float".
-  signed {boolean}: Only used if `type == "int"`
-}
-```
-
-### SourceStructFieldDefinition
+### SourceTypeField
 ```
 {
   name {string}: Name of field on struct.
-  sTypeIndex {integer}: Index into SourceTypeDefinition array of the type that this field is.
+  sTypeIndex {integer}: Index into SourceType array of the type that this field is.
 }
 ```
 

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -307,7 +307,9 @@ Responses:
  - `404`: Execution id not found
     - Returns {[Error](#error)]}
 
-
+## SourceTypeDefinitions and SourceValues transactions (*TODO*)
+### `GET /debug/types/something....`
+Todo....
 
 # Object Definitions
 
@@ -415,12 +417,12 @@ Responses:
 {
   id {var id}: Unique identifier of that variable.
   name {string}: Name of the variable as it appears in the function.
-  sTypeIndex {number}: Index to the variable in the SourceType[] as it is defined in the source code.
+  sValueIndex {number}: Index to the variable in the SourceValue[] as it is defined in the source code.
   address {integer}: Memory address
 }
 ```
 
-### SourceType
+### SourceValue
 ```
 {
   sTypeIndex {integer}: Index into SourceTypeDefinition array of the type that this variable is.
@@ -434,14 +436,14 @@ Responses:
 ```
 {
   kind {string}: Type of variable. Can be "primitive" | "pointer" | "struct".
-  primitive {SourcePrimativeDefinition}: Only used if `kind == "primitive"`. Defines primitive information
+  primitive {SourcePrimitiveDefinition}: Only used if `kind == "primitive"`. Defines primitive information
   sTypeIndex {integer}: Only used if `kind == "pointer"`. Index into array of SourceTypeDefinitions array of the type that this pointer points to.
   name {string}: Only used if `kind == "struct"`. Name of the struct as used in source code.
   fields {SourceStructFieldDefinition[]}: Only used if `kind == "struct"`. Array of fields on this struct.
 }
 ```
 
-### SourcePrimativeDefinition
+### SourcePrimitiveDefinition
 ```
 {
   type {string}: Type of primitive. Can be "void" | "bool" | "int" | "float".


### PR DESCRIPTION
Also cleans up some small issues with the API with regards to field names using protecting terms like `function`.

#25 