### PR TITLE
Match height optimization

### DIFF
--- a/client/app/components/functions/functions.component.ts
+++ b/client/app/components/functions/functions.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit, AfterViewChecked} from "@angular/core";
+import {Component, OnInit} from "@angular/core";
 import {SourceFunction} from "../../models/SourceFunction";
 import {DebuggerService} from "../../services/debugger.service";
 import {DebuggerState} from "../../models/DebuggerState";
@@ -18,7 +18,7 @@ import {SourceFunctionId} from "../../models/SourceFunctionId";
     selector: 'spice-configuration',
     templateUrl: 'app/components/functions/functions.component.html'
 })
-export class FunctionsComponent implements OnInit, AfterViewChecked {
+export class FunctionsComponent implements OnInit {
 
     private _configurationContentBody:HTMLElement | null;
 
@@ -35,7 +35,7 @@ export class FunctionsComponent implements OnInit, AfterViewChecked {
                 private fileSystemService: FileSystemService) {
         this.selectedFunction = null;
         this.debugState = null;
-        this.lines = null;
+        this.lines = [];
     }
 
     public ngOnInit() {
@@ -44,13 +44,6 @@ export class FunctionsComponent implements OnInit, AfterViewChecked {
             console.error('Error getting ConfigurationContainer');
         }
     }
-
-    public ngAfterViewChecked() {
-		//TODO: fix this so it doesn't just execute on any update
-		if(this.lines) {
-			this.lines.forEach((l,i) => MatchMaxHeightDirective.update('functions-'+i.toString()));
-		}
-	}
 
     public ToggleBreakpoint() {
         if(this.selectedFunction && this.debugState) {
@@ -101,8 +94,7 @@ export class FunctionsComponent implements OnInit, AfterViewChecked {
         this.fileSystemService.getFileContents($event.sourcePath).subscribe((contents:string)=> {
             this.lines = contents.split('\n');
             this.linesLoaded = true;
-            //TODO: figure out how to do this without a delay
-            //Observable.of(null).delay(100).subscribe(() => this.refreshHeights());
+            this.refreshHeights();
         }, (error:Error)=> {
             this.lines = [];
             this.linesLoaded = false;
@@ -121,7 +113,7 @@ export class FunctionsComponent implements OnInit, AfterViewChecked {
 
     public refreshHeights(): void {
         if(!!this.lines) {
-            this.lines.forEach((l,i) => MatchMaxHeightDirective.update('functions-'+i.toString()));
+            this.lines.forEach((l,i) => MatchMaxHeightDirective.markDirty('functions-'+i.toString()));
         }
     }
 

--- a/client/app/rxjs-extensions.ts
+++ b/client/app/rxjs-extensions.ts
@@ -2,6 +2,7 @@
 import 'rxjs/add/observable/of';
 import 'rxjs/add/observable/throw';
 import 'rxjs/add/observable/from';
+import 'rxjs/add/observable/interval';
 
 // Observable operators
 import 'rxjs/add/operator/catch';

--- a/client/package.json
+++ b/client/package.json
@@ -39,7 +39,7 @@
     "zone.js": "^0.7.6"
   },
   "devDependencies": {
-    "@types/jasmine": "^2.5.36",
+    "@types/jasmine": "2.5.41",
     "@types/node": "^6.0.46",
     "canonical-path": "0.0.2",
     "concurrently": "^3.1.0",


### PR DESCRIPTION
Closes #72 

Users of the MatchMaxHeightDirective call `markDirty` for ids they've updated, which are adds them to an update list which periodically updates directives with that id for a fixed amount of time (since we can't detect when specific view changes are actually rendered).