### PR TITLE
Recursion

### DIFF
--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -389,6 +389,7 @@ Responses:
     line: integer; // line number that produced this trace
     data:
         { tType: "line"; state: TraceState[]; } // state of changed variables
+        { tType: "call"; sFunction: integer; args: *[]; } // breakpointed callee function
         { tType: "return"; value: *; } // function return value
         { tType: "break"; nextExecution: integer; } // id of the following execution
         { tType: "exit"; code: integer; } // process exit code

--- a/server/debug/examples/attach.rs
+++ b/server/debug/examples/attach.rs
@@ -16,7 +16,7 @@ fn main() {
     debug::SymbolHandler::set_options(winapi::SYMOPT_DEBUG | winapi::SYMOPT_LOAD_LINES | options);
 
     let mut threads = HashMap::new();
-    let mut symbols = debug::SymbolHandler::initialize(&child)
+    let symbols = debug::SymbolHandler::initialize(&child)
         .expect("failed to initialize symbol handler");
 
     let mut done = false;

--- a/server/debug/examples/call.rs
+++ b/server/debug/examples/call.rs
@@ -6,7 +6,7 @@ use std::env;
 use std::collections::HashMap;
 
 fn main() {
-    let mut child = debug::Command::new(env::args().nth(1).unwrap())
+    let child = debug::Command::new(env::args().nth(1).unwrap())
         .env_clear()
         .debug()
         .expect("failed to launch process");
@@ -16,7 +16,7 @@ fn main() {
     debug::SymbolHandler::set_options(winapi::SYMOPT_DEBUG | winapi::SYMOPT_LOAD_LINES | options);
 
     let mut threads = HashMap::new();
-    let mut symbols = debug::SymbolHandler::initialize(&child)
+    let symbols = debug::SymbolHandler::initialize(&child)
         .expect("failed to initialize symbol handler");
 
     let mut attached = false;
@@ -83,7 +83,7 @@ fn main() {
                         ];
 
                         let call = debug::Call::setup(
-                            &mut child, &mut context, &symbols, &function, args 
+                            &child, &symbols, &mut context, &function, args
                         ).expect("failed to set up function call");
                         debug::set_thread_context(thread, &context)
                             .expect("failed to set context");

--- a/server/debug/examples/enumerate.rs
+++ b/server/debug/examples/enumerate.rs
@@ -15,7 +15,7 @@ fn main() {
     debug::SymbolHandler::set_options(winapi::SYMOPT_DEBUG | winapi::SYMOPT_LOAD_LINES | options);
 
     let mut threads = HashMap::new();
-    let mut symbols = debug::SymbolHandler::initialize(&child)
+    let symbols = debug::SymbolHandler::initialize(&child)
         .expect("failed to initialize symbol handler");
 
     let mut done = false;

--- a/server/debug/examples/function.rs
+++ b/server/debug/examples/function.rs
@@ -6,7 +6,7 @@ use std::env;
 use std::collections::HashMap;
 
 fn main() {
-    let mut child = debug::Command::new(env::args().nth(1).unwrap())
+    let child = debug::Command::new(env::args().nth(1).unwrap())
         .env_clear()
         .debug()
         .expect("failed to launch process");
@@ -16,7 +16,7 @@ fn main() {
     debug::SymbolHandler::set_options(winapi::SYMOPT_DEBUG | winapi::SYMOPT_LOAD_LINES | options);
 
     let mut threads = HashMap::new();
-    let mut symbols = debug::SymbolHandler::initialize(&child)
+    let symbols = debug::SymbolHandler::initialize(&child)
         .expect("failed to initialize symbol handler");
 
     let mut attached = false;

--- a/server/debug/examples/trace.rs
+++ b/server/debug/examples/trace.rs
@@ -15,7 +15,7 @@ fn main() {
     debug::SymbolHandler::set_options(winapi::SYMOPT_DEBUG | winapi::SYMOPT_LOAD_LINES | options);
 
     let mut threads = HashMap::new();
-    let mut symbols = debug::SymbolHandler::initialize(&child)
+    let symbols = debug::SymbolHandler::initialize(&child)
         .expect("failed to initialize symbol handler");
 
     let mut attached = false;

--- a/server/debug/examples/types.rs
+++ b/server/debug/examples/types.rs
@@ -16,7 +16,7 @@ fn main() {
     debug::SymbolHandler::set_options(winapi::SYMOPT_DEBUG | winapi::SYMOPT_LOAD_LINES | options);
 
     let mut threads = HashMap::new();
-    let mut symbols = debug::SymbolHandler::initialize(&child)
+    let symbols = debug::SymbolHandler::initialize(&child)
         .expect("failed to initialize symbol handler");
 
     let mut done = false;

--- a/server/debug/src/call.rs
+++ b/server/debug/src/call.rs
@@ -18,8 +18,8 @@ impl Call {
     }
 
     pub fn setup(
-        child: &mut Child, context: &mut Context, symbols: &SymbolHandler,
-        function: &Symbol, args: Vec<Value>
+        child: &Child, symbols: &SymbolHandler,
+        context: &mut Context, function: &Symbol, args: Vec<Value>
     ) -> io::Result<Call> {
         let (module, return_type, arg_types) = get_function_types(symbols, function)?;
 
@@ -135,7 +135,7 @@ fn get_function_types(symbols: &SymbolHandler, function: &Symbol) ->
 }
 
 fn write_value(
-    arg: &Value, arg_type: &Type, child: &mut Child, context: &mut Context
+    arg: &Value, arg_type: &Type, child: &Child, context: &mut Context
 ) -> io::Result<(usize, bool)> {
     if &arg.data_type != arg_type {
         return Err(io::Error::new(io::ErrorKind::InvalidInput, "argument types do not match"));

--- a/server/debug/src/lib.rs
+++ b/server/debug/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(optin_builtin_traits)]
-#![feature(field_init_shorthand)]
 #![feature(associated_consts)]
 
 extern crate winapi;

--- a/server/debug/src/process.rs
+++ b/server/debug/src/process.rs
@@ -31,7 +31,7 @@ impl Child {
     }
 
     /// Write `buffer.len()` bytes into a process's address space at `address`
-    pub fn write_memory(&mut self, address: usize, buffer: &[u8]) -> io::Result<usize> {
+    pub fn write_memory(&self, address: usize, buffer: &[u8]) -> io::Result<usize> {
         unsafe {
             let mut written = 0;
             if kernel32::WriteProcessMemory(
@@ -46,19 +46,19 @@ impl Child {
         }
     }
 
-    pub fn set_breakpoint(&mut self, address: usize) -> io::Result<Breakpoint> {
+    pub fn set_breakpoint(&self, address: usize) -> io::Result<Breakpoint> {
         let mut saved = [0u8; 1];
         self.read_memory(address, &mut saved)?;
         self.write_memory(address, &[0xCCu8])?;
         Ok(Breakpoint { address, saved })
     }
 
-    pub fn remove_breakpoint(&mut self, breakpoint: Breakpoint) -> io::Result<()> {
+    pub fn remove_breakpoint(&self, breakpoint: Breakpoint) -> io::Result<()> {
         self.write_memory(breakpoint.address, &breakpoint.saved)?;
         Ok(())
     }
 
-    pub fn stack_push<B: AsBytes>(&mut self, context: &mut Context, value: B) -> io::Result<()> {
+    pub fn stack_push<B: AsBytes>(&self, context: &mut Context, value: B) -> io::Result<()> {
         let bytes = value.as_bytes();
         let address = context.stack_pointer() - bytes.len();
 

--- a/server/debug/src/symbol.rs
+++ b/server/debug/src/symbol.rs
@@ -54,7 +54,7 @@ impl SymbolHandler {
     }
 
     /// Load the symbols for a module
-    pub fn load_module(&mut self, file: &File, base: usize) -> io::Result<()> {
+    pub fn load_module(&self, file: &File, base: usize) -> io::Result<()> {
         unsafe {
             // TODO: if we want to enable deferred symbol loading, we need to pass module size too
             if dbghelp::SymLoadModuleExW(
@@ -69,7 +69,7 @@ impl SymbolHandler {
     }
 
     /// Unload the symbols for a module
-    pub fn unload_module(&mut self, base: usize) -> io::Result<()> {
+    pub fn unload_module(&self, base: usize) -> io::Result<()> {
         unsafe {
             if dbghelp::SymUnloadModule64(self.0, base as winapi::DWORD64) == winapi::FALSE {
                 return Err(io::Error::last_os_error());

--- a/server/src/api.rs
+++ b/server/src/api.rs
@@ -100,12 +100,17 @@ pub struct Trace {
 pub enum TraceData {
     #[serde(rename = "line")]
     Line { state: Vec<TraceState> },
+    #[serde(rename = "call")]
+    Call {
+        #[serde(rename = "sFunction")]
+        function: usize,
+    },
     #[serde(rename = "return")]
     Return { value: String },
     #[serde(rename = "break")]
     Break {
         #[serde(rename = "nextExecution")]
-        next_execution: i32
+        next_execution: i32,
     },
     #[serde(rename = "exit")]
     Exit { code: u32 },

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(field_init_shorthand)]
-
 extern crate hyper;
 extern crate unicase;
 extern crate reroute;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -685,16 +685,17 @@ fn trace_stream(res: &mut Response<Streaming>, child: &mut child::Thread) -> io:
 
     res.write_all(b"[\n")?;
 
-    let mut index = 0;
+    let mut next_index = 0;
     let mut prev_locals = HashMap::new();
 
     let mut terminated = false;
+    let mut stack: usize = 0;
     let mut done = false;
     while !done {
         let message = match child.rx.recv().unwrap() {
             DebugMessage::Trace(DebugTrace::Line(line, locals)) => {
-                let this_index = index;
-                index += 1;
+                let index = next_index;
+                next_index += 1;
 
                 let mut state = vec![];
                 for &(ref name, ref value) in locals.iter() {
@@ -708,16 +709,32 @@ fn trace_stream(res: &mut Response<Streaming>, child: &mut child::Thread) -> io:
                 }
                 prev_locals.extend(locals.into_iter());
 
-                let data = api::TraceData::Line { state: state };
-                api::Trace { index: this_index, line: line, data: data }
+                let data = api::TraceData::Line { state };
+                api::Trace { index, line, data }
+            }
+
+            DebugMessage::Trace(DebugTrace::Call(line, function)) => {
+                let index = next_index;
+                next_index += 1;
+
+                stack += 1;
+
+                let data = api::TraceData::Call { function };
+                api::Trace { index, line, data }
             }
 
             DebugMessage::Trace(DebugTrace::Return(line, value)) => {
-                done = true;
-                child.execution = None;
+                let index = next_index;
+                next_index += 1;
 
-                let data = api::TraceData::Return { value: value };
-                api::Trace { index: index, line: line, data: data }
+                stack -= 1;
+                if stack == 0 {
+                    done = true;
+                    child.execution = None;
+                }
+
+                let data = api::TraceData::Return { value };
+                api::Trace { index, line, data }
             }
 
             DebugMessage::Trace(DebugTrace::Breakpoint(address)) => {
@@ -727,7 +744,7 @@ fn trace_stream(res: &mut Response<Streaming>, child: &mut child::Thread) -> io:
                 child.execution = Some((id, child::Execution::Function(address)));
 
                 let data = api::TraceData::Break { next_execution: id };
-                api::Trace { index: 0, line: 0, data: data }
+                api::Trace { index: next_index, line: 0, data }
             }
 
             DebugMessage::Trace(DebugTrace::Exit(code)) => {
@@ -736,7 +753,7 @@ fn trace_stream(res: &mut Response<Streaming>, child: &mut child::Thread) -> io:
                 child.execution = None;
 
                 let data = api::TraceData::Exit { code: code };
-                api::Trace { index: 0, line: 0, data: data }
+                api::Trace { index: next_index, line: 0, data }
             }
 
             // TODO: collect stack trace in child thread
@@ -746,7 +763,7 @@ fn trace_stream(res: &mut Response<Streaming>, child: &mut child::Thread) -> io:
                 child.execution = None;
 
                 let data = api::TraceData::Crash { stack: String::new() };
-                api::Trace { index: 0, line: 0, data: data }
+                api::Trace { index: next_index, line: 0, data }
             }
 
             DebugMessage::Error(e) => {


### PR DESCRIPTION
This handles function calls in traces- recursive and otherwise. There is a new "call" trace type that is now sent when a breakpointed function is called, to match its "return" trace. This includes the initial call from `function/:id/execute`, as well as further recursive calls to that function (accomplished by adding a new breakpoint to that function if one does not exist).

I have tested it with regular function calls and recursive function calls, but (for reference) not mutually recursive or tail-recursive calls, though I don't expect any issues there.

This is a massive restructuring of `child.rs`- it might be easier to review if you look at the commits rather than the overall diff.

Closes #69 
Closes #71