### PR TITLE
List drives when requesting filesystem root

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.1.0"
 dependencies = [
  "debug 0.1.0",
  "hyper 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (git+https://github.com/team-worm/winapi-rs)",
  "mime_guess 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reroute 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -16,3 +16,4 @@ serde_derive = "0.9.6"
 serde_json = "0.9"
 debug = { path = "debug" }
 winapi = { git = "https://github.com/team-worm/winapi-rs" }
+kernel32-sys = { git = "https://github.com/team-worm/winapi-rs" }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -11,6 +11,7 @@ extern crate serde_json;
 
 extern crate debug;
 extern crate winapi;
+extern crate kernel32;
 
 use std::{io, fs};
 use std::sync::{Mutex, Arc};
@@ -327,6 +328,28 @@ fn filesystem(caps: Captures) -> io::Result<Vec<u8>> {
     let caps = caps.unwrap();
     let path = url::percent_encoding::percent_decode(caps[1].as_bytes());
     let path = path.decode_utf8_lossy().into_owned();
+
+    if path.is_empty() {
+        let drives = unsafe { kernel32::GetLogicalDrives() };
+
+        let mut contents = vec![];
+        for drive in (0..26).filter(|i| (drives & (1u32 << i)) != 0).map(|i| b'A' + i) {
+            let path = format!("{}:/", drive as char);
+            let name = format!("{}:", drive as char);
+            let data = api::FileData::Directory { contents: None };
+
+            contents.push(api::File { name, path, data });
+        }
+        let data = api::FileData::Directory { contents: Some(contents) };
+
+        let message = api::File {
+            name: "".into(),
+            path: "".into(),
+            data: data,
+        };
+        return Ok(serde_json::to_vec(&message).unwrap());
+    }
+
     let path = Path::new(&path);
     if !path.exists() {
         return Err(io::Error::from(io::ErrorKind::NotFound));

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -20,7 +20,6 @@ use std::io::{Write};
 use std::path::Path;
 use std::ffi::OsStr;
 use std::collections::HashMap;
-use std::error::Error;
 
 use hyper::status::StatusCode;
 use hyper::server::{Server, Request, Response, Streaming};
@@ -296,7 +295,7 @@ fn send(mut req: Request, mut res: Response, body: &[u8]) -> io::Result<()> {
 fn send_error(req: Request, mut res: Response, error: io::Error) -> io::Result<()> {
     *res.status_mut() = status_from_error(error.kind());
 
-    let message = api::Error { message: error.description().into() };
+    let message = api::Error { message: format!("{}", error) };
     send(req, res, &serde_json::to_vec(&message).unwrap())
 }
 


### PR DESCRIPTION
@samdamana You can now `GET /api/v1/filesystem/` and it will treat it as a directory containing the drives.

Closes #98 