### PR TITLE
Hide toolbar buttons when in launch view

### DIFF
--- a/client/app/components/spice-root.component.ts
+++ b/client/app/components/spice-root.component.ts
@@ -4,14 +4,14 @@ import { DebuggerComponent } from "./debugger/debugger.component";
 import { FunctionsComponent } from "./functions/functions.component";
 import { ToolbarComponent } from "./toolbar/toolbar.component";
 import { LauncherComponent } from "./launcher/launcher.component";
-import {MdSidenav} from "@angular/material";
-import {TraceHistoryComponent} from "./debugger/trace-history/trace-history.component";
+import { MdSidenav } from "@angular/material";
+import { TraceHistoryComponent } from "./debugger/trace-history/trace-history.component";
 
 @Component({
     selector: 'spice-root',
     template: `
 <span [class.spicy-dark]="isDarkTheme">
-    <spice-toolbar ></spice-toolbar>
+    <spice-toolbar></spice-toolbar>
     <md-sidenav-container>
         <spice-launcher [hidden]="!IsInLauncher()"></spice-launcher>
         <spice-configuration [hidden]="!IsInFunctions()"></spice-configuration>
@@ -45,7 +45,7 @@ export class SpiceRootComponent implements OnInit {
         this.traceHistoryComponent.sidenav = this.traceHistory;
     }
 
-    public SetTheme(theme:string) {
+    public SetTheme(theme: string) {
         this.isDarkTheme = !this.isDarkTheme;
     }
 

--- a/client/app/components/toolbar/toolbar.component.html
+++ b/client/app/components/toolbar/toolbar.component.html
@@ -5,24 +5,25 @@
         <span *ngIf="!!debugState" class="target-name">{{processName()}}</span>
     </span>
     <span class="flex-pusher"></span>
-    <button md-button *ngIf="!canContinue()" [disabled]="!canStart()" (click)="ContinueExecution()"><md-icon [color]="'accent'">play_arrow</md-icon> Start</button>
-    <button md-button *ngIf="canContinue()" [disabled]="!canContinue()" (click)="ContinueExecution()"><md-icon [color]="'accent'">skip_next</md-icon> Continue</button>
-    <button md-button [disabled]="!canStopExecution()" (click)="StopExecution()"><md-icon [color]="'accent'">pause</md-icon> Pause</button>
-    <button md-button [disabled]="!canKillProcess()" (click)="KillProcess()"><md-icon [color]="'accent'">stop</md-icon> Stop</button>
-    <button md-button [disabled]="!canDetach()" (click)="Detach()"><md-icon [color]="'accent'">close</md-icon>Detach</button>
-    <span class="left-divider">
-    <button md-button *ngIf="breakpointCount() === 0" [disabled]="!debuggerService.currentDebuggerState || IsInFunctionView()" (click)="GoToFunctionsView()">
-        <md-icon>library_books</md-icon>
-        Functions [{{breakpointCount()}}]
-    </button>
-    <button md-button *ngIf="breakpointCount() > 0" [mdMenuTriggerFor]="breakpointMenu" (click)="GetBpFunctions()">
-        <md-icon>library_books</md-icon>
-        Functions [{{breakpointCount()}}]
-    </button>
-	<button md-button [disabled]="breakpointCount() === 0" (click)="ToggleTraceHistory()">
-        <md-icon>bug_report</md-icon>
-        Debug Traces [{{breakpointCount()}}]
-    </button>
+    <span [hidden]="IsInLauncherView()">
+        <button md-button *ngIf="!canContinue()" [disabled]="!canStart()" (click)="ContinueExecution()"><md-icon [color]="'accent'">play_arrow</md-icon> Start</button>
+        <button md-button *ngIf="canContinue()" [disabled]="!canContinue()" (click)="ContinueExecution()"><md-icon [color]="'accent'">skip_next</md-icon> Continue</button>
+        <button md-button [disabled]="!canStopExecution()" (click)="StopExecution()"><md-icon [color]="'accent'">pause</md-icon> Pause</button>
+        <button md-button [disabled]="!canKillProcess()" (click)="KillProcess()"><md-icon [color]="'accent'">stop</md-icon> Stop</button>
+        <button md-button [disabled]="!canDetach()" (click)="Detach()"><md-icon [color]="'accent'">close</md-icon>Detach</button>
+        <span class="left-divider">
+        <button md-button *ngIf="breakpointCount() === 0" [disabled]="!debuggerService.currentDebuggerState || IsInFunctionView()" (click)="GoToFunctionsView()">
+            <md-icon>library_books</md-icon>
+            Functions [{{breakpointCount()}}]
+        </button>
+        <button md-button *ngIf="breakpointCount() > 0" [mdMenuTriggerFor]="breakpointMenu" (click)="GetBpFunctions()">
+            <md-icon>library_books</md-icon>
+            Functions [{{breakpointCount()}}]
+        </button>
+        <button md-button [disabled]="breakpointCount() === 0" (click)="ToggleTraceHistory()">
+            <md-icon>bug_report</md-icon>
+            Debug Traces [{{breakpointCount()}}]
+        </button>
     </span>
 </md-toolbar>
 

--- a/client/app/components/toolbar/toolbar.component.ts
+++ b/client/app/components/toolbar/toolbar.component.ts
@@ -32,6 +32,11 @@ export class ToolbarComponent {
     public IsInFunctionView(): boolean {
         return this.viewService.activeView === 'functions';
     }
+
+    public IsInLauncherView(): boolean {
+        return this.viewService.activeView === 'launcher';
+    }
+
     public GoToFunctionsView() {
     	this.debuggerService.displayFunction(null);
     }


### PR DESCRIPTION
Hide the toolbar buttons (start, continue, detach, etc.) when in the file picker launcher view.

closes #124 