### PR TITLE
Server cleanup

### DIFF
--- a/server/debug/src/call.rs
+++ b/server/debug/src/call.rs
@@ -79,7 +79,6 @@ impl Call {
         }
 
         // fixup pointers to their actual targets
-        addresses.insert(0, 0);
         for (&address, &target) in &offsets {
             let bytes = addresses[&target].as_bytes();
             child.write_memory(address, bytes)?;

--- a/server/debug/src/event.rs
+++ b/server/debug/src/event.rs
@@ -159,7 +159,6 @@ impl Event {
 
         self.continue_status(status)?;
 
-        mem::forget(self);
         Ok(())
     }
 
@@ -173,11 +172,5 @@ impl Event {
         }
 
         Ok(())
-    }
-}
-
-impl Drop for Event {
-    fn drop(&mut self) {
-        let _ = self.continue_status(winapi::DBG_EXCEPTION_NOT_HANDLED as winapi::DWORD);
     }
 }

--- a/server/debug/src/symbol.rs
+++ b/server/debug/src/symbol.rs
@@ -205,7 +205,7 @@ impl SymbolHandler {
             Ok(Type::Pointer { type_index: target })
         } else if tag == winapi::SymTagArrayType {
             let TypeIndex(element) = self.get_type_info(module, type_index)?;
-            let TypeChildren(count) = self.get_type_info(module, type_index)?;
+            let TypeCount(count) = self.get_type_info(module, type_index)?;
             Ok(Type::Array { type_index: element, count: count as usize })
         } else if tag == winapi::SymTagFunctionType {
             let TypeCallingConvention(cc) = self.get_type_info(module, type_index)?;
@@ -485,6 +485,11 @@ debug_property!(BasicType, winapi::TI_GET_BASETYPE);
 #[allow(dead_code)]
 struct TypeOffset(winapi::DWORD);
 debug_property!(TypeOffset, winapi::TI_GET_OFFSET);
+
+#[repr(C)]
+#[allow(dead_code)]
+struct TypeCount(winapi::DWORD);
+debug_property!(TypeCount, winapi::TI_GET_COUNT);
 
 #[repr(C)]
 #[allow(dead_code)]

--- a/server/src/value.rs
+++ b/server/src/value.rs
@@ -94,8 +94,11 @@ pub fn trace_pointers(
     pointers: &mut VecDeque<(usize, u32)>, values: &mut HashMap<usize, api::Value>
 ) {
     while let Some((address, type_index)) = pointers.pop_front() {
-        let offset = address - base;
-        if values.contains_key(&address) || values.contains_key(&offset) {
+        let offset = address.checked_sub(base);
+        if
+            values.contains_key(&address) ||
+            offset.map(|offset| values.contains_key(&offset)).unwrap_or(false)
+        {
             continue;
         }
 

--- a/server/src/value.rs
+++ b/server/src/value.rs
@@ -160,6 +160,8 @@ impl debug::IntoValue for api::Value {
                 pointers.push_back((value as usize, type_index));
             }
 
+            (&Pointer { .. }, api::Value::Null) => {}
+
             (&Array { type_index, count }, api::Value::Array(values)) => {
                 if count != values.len() {
                     return Err(io::Error::from(io::ErrorKind::InvalidInput));


### PR DESCRIPTION
In addition to two previous fixes folded into a frontend branch:
- collect enum base types
- leave out non-field type children

Fix three other server issues:
- don't panic on pointers specified by offset, when subtracting the stack frame pointer
- collect element count for arrays rather than type child count
- don't leak file handles from debug events in `continue_event`
- treat `null` as a null pointer and leave `0` as a valid key